### PR TITLE
[T2213] : Fixed adding debit invoices when mandate is not active

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -85,9 +85,11 @@ class AccountMove(models.Model):
                 raise UserError(_("The invoice %s is not in Posted state") % move.name)
 
             # Check if mandate status is not cancel
-            if move.mandate_id.state == 'cancel':
-                raise UserError(_("The mandate %s is in Cancel state") %
-                                move.mandate_id.display_name)
+            if move.mandate_id.state == "cancel":
+                raise UserError(
+                    _("The mandate %s is in Cancel state")
+                    % move.mandate_id.display_name
+                )
 
             applicable_lines = move.line_ids.filtered(
                 lambda x: (

--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -83,6 +83,12 @@ class AccountMove(models.Model):
         for move in self:
             if move.state != "posted":
                 raise UserError(_("The invoice %s is not in Posted state") % move.name)
+
+            # Check if mandate status is not cancel
+            if move.mandate_id.state == 'cancel':
+                raise UserError(_("The mandate %s is in Cancel state") %
+                                move.mandate_id.display_name)
+
             applicable_lines = move.line_ids.filtered(
                 lambda x: (
                     not x.reconciled

--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -85,9 +85,9 @@ class AccountMove(models.Model):
                 raise UserError(_("The invoice %s is not in Posted state") % move.name)
 
             # Check if mandate status is not cancel
-            if move.mandate_id.state == "cancel":
+            if move.mandate_id.state != "valid":
                 raise UserError(
-                    _("The mandate %s is in Cancel state")
+                    _("The mandate %s is not valid.")
                     % move.mandate_id.display_name
                 )
 


### PR DESCRIPTION
Added a test before the invoice debit logic where we check the state of mandate in  account.move.
If it is 'Cancel', we raise the error with a message and we don't let the rest of the code follow (note : an invoice can be added only one time, so the test has to be done early in the function)

